### PR TITLE
removed duplicate option from config.sample.php

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -19,8 +19,6 @@ $config['db_prefix']    = 'videodb_';   // Database table prefix (for use in hos
 
 $config['offline']      = 0;            // Use to take videoDB offline
 
-$config['offline']          = 0;        // videoDB is offline
-
 // Boxee box configuration
 $config['boxeeHost']        	= '';	// boxee box host
 $config['boxeePort']        	= 9090;	// boxee box port


### PR DESCRIPTION
The commit 121728de introduced a second line in the example-config
that sets $config['offline'] to zero. As long as I'm not missing anything this seems superfluous to me.

This pull-request removes the duplicate entry from config.sample.php.
