### PR TITLE
Added OFDB scraper because OFDBGW does not provide full data

### DIFF
--- a/engines/ofdbscraper.php
+++ b/engines/ofdbscraper.php
@@ -238,7 +238,11 @@ function ofdbscraperData($id)
 	}
 
 	// Cover URL
-    if (preg_match('#<img src="(http://img.ofdb.de/film/.*?\.jpg)"#i', $resp['data'], $ary))
+    if (preg_match('#<img src="(http://img.ofdb.de/film/na.gif)"#i', $resp['data'], $ary))
+    {
+        $data['coverurl'] = "";
+    }
+    else if (preg_match('#<img src="(http://img.ofdb.de/film/.*?\.jpg)"#i', $resp['data'], $ary))
     {
         $data['coverurl'] =  trim($ary[1]);
     }


### PR DESCRIPTION
This is the "good old" OFDB scraper with some issues fixed. It works for the time being and since I use it, I'll try to keep ip up to date. 

Notice it will NOT load language information (since OFDB does not provide them "per movie" but "per edition" and it is not possible to select the edition). 

Downside of using OFDB is, that their covers are rather small and NextGen doesn't look too good with the smaller ones (especially when enabling movie titles above the images). 
