### PR TITLE
Update add_recommended_movies.php

### DIFF
--- a/contrib/add_recommended_movies.php
+++ b/contrib/add_recommended_movies.php
@@ -61,7 +61,7 @@ if ($submit)
             echo "Fetching recommendations for {$video['title']} (IMDB Id {$video['imdbID']})<br/>\n";
             flush();
 
-            $url = 'http://uk.imdb.com/title/tt'.$video['imdbID'].'/recommendations';
+            $url = engineGetRecommendationsUrl($video['imdbID'], 'imdb');
 
             $resp = httpClient($url, true);
             if (!$resp['success']) 
@@ -96,7 +96,7 @@ if ($submit)
 
                 if (empty($rating) || ($rating >= $required_rating))
                 {
-                    $available = (count(runSQL("SELECT * FROM ".TBL_DATA." WHERE imdbID = '$id'")) > 0);
+                    $available = (count(runSQL("SELECT * FROM ".TBL_DATA." WHERE imdbID like '%$id'")) > 0);
 
                     if ($available)
                     {


### PR DESCRIPTION
add_recommended_movies now uses engine.php to get the url for recommended movies.
The sql that check if a movie already is in the database now uses 'like %IMDB_ID' to support imdb id with and with prefix.
