### PR TITLE
Genre translations

### DIFF
--- a/core/output.php
+++ b/core/output.php
@@ -35,7 +35,7 @@ function getGenres()
  */
 function out_genres($selected)
 {
-    global $config;
+    global $config,$lang;
 
     $result = getGenres();
 	$out = '<table class="genreselect"><tr>';
@@ -60,7 +60,7 @@ function out_genres($selected)
 			$out .= ' checked="checked"';
 		}
 		$out .= '/>';
-		$out .= '<label for="genreid'.$res['id'].'">'.$res['name'].'</label>';
+		$out .= '<label for="genreid'.$res['id'].'">'.$lang[$res['name']].'</label>';
 		$out .= '</td>';
         if ((++$row % 5) == 0)
         {

--- a/core/output.php
+++ b/core/output.php
@@ -60,7 +60,7 @@ function out_genres($selected)
 			$out .= ' checked="checked"';
 		}
 		$out .= '/>';
-		$out .= '<label for="genreid'.$res['id'].'">'.$lang[$res['name']].'</label>';
+		$out .= '<label for="genreid'.$res['id'].'">'.(isset($lang[$res['name']]) ? $lang[$res['name']] : $res['name']).'</label>';
 		$out .= '</td>';
         if ((++$row % 5) == 0)
         {

--- a/language/de.php
+++ b/language/de.php
@@ -284,4 +284,32 @@ $lang['warn_noOwner']        = "Daten nicht gespeichert - bitte wählen einen Be
 
 $lang['order']				 = "Sortierung";
 
+#
+# Genres
+#
+$lang['Action']		= 'Action';
+$lang['Adventure']	= 'Abenteuer';
+$lang['Animation']	= 'Animation';
+$lang['Comedy']		= 'Komödie';
+$lang['Crime']		= 'Krimi';
+$lang['Documentary']= 'Dokumentarfilm';
+$lang['Drama']		= 'Drama';
+$lang['Family']		= 'Familienfilm';
+$lang['Fantasy']	= 'Fantasy';
+$lang['Film-Noir']	= 'Film noir';
+$lang['Horror']		= 'Horror';
+$lang['Musical']	= 'Musical';
+$lang['Mystery']	= 'Mysteryfilm';
+$lang['Romance']	= 'Romanze';
+$lang['Sci-Fi']		= 'Science fiction';
+$lang['Short']		= 'Kurzfilm';
+$lang['Thriller']	= 'Thriller';
+$lang['War']		= 'Kriegfilm';
+$lang['Western']	= 'Western';
+$lang['Adult']		= 'Erwachsen';
+$lang['Music']		= 'Musik';
+$lang['Biography']	= 'Biografie';
+$lang['History']	= 'Geschichte';
+$lang['Sport']		= 'Sport';
+
 ?>

--- a/language/en.php
+++ b/language/en.php
@@ -338,32 +338,4 @@ $lang['warn_noOwner']        = "Data not saved - you have to select an owner fir
 
 $lang['order']				 = "Sort by";
 
-#
-# Genres
-#
-$lang['Action']		= 'Action';
-$lang['Adventure']	= 'Adventure';
-$lang['Animation']	= 'Animation';
-$lang['Comedy']		= 'Comedy';
-$lang['Crime']		= 'Crime';
-$lang['Documentary']= 'Documentary';
-$lang['Drama']		= 'Drama';
-$lang['Family']		= 'Familiy';
-$lang['Fantasy']	= 'Fantasy';
-$lang['Film-Noir']	= 'Film-Noir';
-$lang['Horror']		= 'Horror';
-$lang['Musical']	= 'Musical';
-$lang['Mystery']	= 'Mystery';
-$lang['Romance']	= 'Romance';
-$lang['Sci-Fi']		= 'Sci-Fi';
-$lang['Short']		= 'Short';
-$lang['Thriller']	= 'Thriller';
-$lang['War']		= 'War';
-$lang['Western']	= 'Western';
-$lang['Adult']		= 'Adult';
-$lang['Music']		= 'Music';
-$lang['Biography']	= 'Biography';
-$lang['History']	= 'History';
-$lang['Sport']		= 'Sport';
-
 ?>

--- a/language/en.php
+++ b/language/en.php
@@ -338,4 +338,32 @@ $lang['warn_noOwner']        = "Data not saved - you have to select an owner fir
 
 $lang['order']				 = "Sort by";
 
+#
+# Genres
+#
+$lang['Action']		= 'Action';
+$lang['Adventure']	= 'Adventure';
+$lang['Animation']	= 'Animation';
+$lang['Comedy']		= 'Comedy';
+$lang['Crime']		= 'Crime';
+$lang['Documentary']= 'Documentary';
+$lang['Drama']		= 'Drama';
+$lang['Family']		= 'Familiy';
+$lang['Fantasy']	= 'Fantasy';
+$lang['Film-Noir']	= 'Film-Noir';
+$lang['Horror']		= 'Horror';
+$lang['Musical']	= 'Musical';
+$lang['Mystery']	= 'Mystery';
+$lang['Romance']	= 'Romance';
+$lang['Sci-Fi']		= 'Sci-Fi';
+$lang['Short']		= 'Short';
+$lang['Thriller']	= 'Thriller';
+$lang['War']		= 'War';
+$lang['Western']	= 'Western';
+$lang['Adult']		= 'Adult';
+$lang['Music']		= 'Music';
+$lang['Biography']	= 'Biography';
+$lang['History']	= 'History';
+$lang['Sport']		= 'Sport';
+
 ?>

--- a/language/es.php
+++ b/language/es.php
@@ -236,4 +236,32 @@ $lang['page']                = "P&aacute;gina";
 $lang['of']                  = "de";
 $lang['records']             = "registros";
 
+#
+# Genres
+#
+$lang['Action']		= 'Acción';
+$lang['Adventure']	= 'Aventura';
+$lang['Animation']	= 'Animación';
+$lang['Comedy']		= 'Comedia';
+$lang['Crime']		= 'Crimen';
+$lang['Documentary']= 'Documental';
+$lang['Drama']		= 'Drama';
+$lang['Family']		= 'Familia';
+$lang['Fantasy']	= 'Fantasía';
+$lang['Film-Noir']	= 'Cine negro';
+$lang['Horror']		= 'Terror';
+$lang['Musical']	= 'Comedia musical';
+$lang['Mystery']	= 'Misterio';
+$lang['Romance']	= 'Romántico';
+$lang['Sci-Fi']		= 'Ciencia ficción';
+$lang['Short']		= 'Cortometraje ';
+$lang['Thriller']	= 'Suspense';
+$lang['War']		= 'Guerra';
+$lang['Western']	= 'Western';
+$lang['Adult']		= 'Adulto';
+$lang['Music']		= 'Musical';
+$lang['Biography']	= 'Biografía';
+$lang['History']	= 'Histórico';
+$lang['Sport']		= 'Deporte';
+
 ?>

--- a/language/fr.php
+++ b/language/fr.php
@@ -260,4 +260,33 @@ $lang['help_showtools']      = "Le menu utilitaires affichera le contenu du rép
 
 $lang['warn_noOwner']        = "Données non sauvées - vous devez préalablement sélectionner un propriétaire !";
 
+#
+# Genres
+#
+$lang['Action']		= 'Action';
+$lang['Adventure']	= 'Aventure';
+$lang['Animation']	= 'Animation';
+$lang['Comedy']		= 'Comédie';
+$lang['Crime']		= 'Policier';
+$lang['Documentary']= 'Documentaire';
+$lang['Drama']		= 'Drame';
+$lang['Family']		= 'Famille';
+$lang['Fantasy']	= 'Fantastique';
+$lang['Film-Noir']	= 'Film noir';
+$lang['Horror']		= 'Epouvante-horreur';
+$lang['Musical']	= 'Comédie musicale';
+$lang['Mystery']	= 'Mistère';
+$lang['Romance']	= 'Romance';
+$lang['Sci-Fi']		= 'Science fiction';
+$lang['Short']		= 'Court métrage';
+$lang['Thriller']	= 'Thriller';
+$lang['War']		= 'Guerre';
+$lang['Western']	= 'Western';
+$lang['Adult']		= 'Adulte';
+$lang['Music']		= 'Musical';
+$lang['Biography']	= 'Biopic';
+$lang['History']	= 'Historique';
+$lang['Sport']		= 'Sport';
+
+
 ?>

--- a/language/pl.php
+++ b/language/pl.php
@@ -338,4 +338,32 @@ $lang['warn_noOwner']        = "Dane nie zachowane - najpierw wybierz właścici
 
 $lang['order']				 = "Sortuj";
 
+#
+# Genres
+#
+$lang['Action']		= 'Akcja';
+$lang['Adventure']	= 'Przygoda';
+$lang['Animation']	= 'Animowany';
+$lang['Comedy']		= 'Komedia';
+$lang['Crime']		= 'Kryminał';
+$lang['Documentary']= 'Dokument';
+$lang['Drama']		= 'Dramat';
+$lang['Family']		= 'Familijny';
+$lang['Fantasy']	= 'Fantasy';
+$lang['Film-Noir']	= 'Film-Noir';
+$lang['Horror']		= 'Horror';
+$lang['Musical']	= 'Musical';
+$lang['Mystery']	= 'Tajemnica';
+$lang['Romance']	= 'Romans';
+$lang['Sci-Fi']		= 'Sci-Fi';
+$lang['Short']		= 'Krótkometrażowy';
+$lang['Thriller']	= 'Thriller';
+$lang['War']		= 'Wojenny';
+$lang['Western']	= 'Western';
+$lang['Adult']		= 'Dla dorosłych';
+$lang['Music']		= 'Muzyczny';
+$lang['Biography']	= 'Biografia';
+$lang['History']	= 'Historia';
+$lang['Sport']		= 'Sport';
+
 ?>

--- a/templates/default/show.tpl
+++ b/templates/default/show.tpl
@@ -115,7 +115,7 @@
       {if $genres}
         <b>{$lang.genres}:</b><br />
           {foreach item=genre from=$genres}
-              <a href="search.php?q=&genres[]={$genre.id}">{$genre.name}</a><br />
+              <a href="search.php?q=&genres[]={$genre.id}">{$lang.{$genre.name}}</a><br />
           {/foreach}
       {/if}
     </td>

--- a/templates/default/show.tpl
+++ b/templates/default/show.tpl
@@ -115,7 +115,7 @@
       {if $genres}
         <b>{$lang.genres}:</b><br />
           {foreach item=genre from=$genres}
-              <a href="search.php?q=&genres[]={$genre.id}">{$lang.{$genre.name}}</a><br />
+              <a href="search.php?q=&genres[]={$genre.id}">{if $lang.{$genre.name}} {$lang.{$genre.name}} {else} {$genre.name} {/if}</a><br />
           {/foreach}
       {/if}
     </td>

--- a/templates/default/stats.tpl
+++ b/templates/default/stats.tpl
@@ -30,7 +30,7 @@
           <td><b>{$lang.videobygen}:</b><br />{$lang.multiple}</td>
           <td>
             {foreach item=row from=$stats.count_genre}
-              <a href="search.php?q=&genres[]={$row.id}">{$lang.{$row.name}}</a> : {$row.count}<br />
+              <a href="search.php?q=&genres[]={$row.id}">{if $lang.{$row.name}} {$lang.{$row.name}} {else} {$row.name} {/if}</a> : {$row.count}<br />
             {/foreach}
           </td>
         </tr>

--- a/templates/default/stats.tpl
+++ b/templates/default/stats.tpl
@@ -30,7 +30,7 @@
           <td><b>{$lang.videobygen}:</b><br />{$lang.multiple}</td>
           <td>
             {foreach item=row from=$stats.count_genre}
-              <a href="search.php?q=&genres[]={$row.id}">{$row.name}</a> : {$row.count}<br />
+              <a href="search.php?q=&genres[]={$row.id}">{$lang.{$row.name}}</a> : {$row.count}<br />
             {/foreach}
           </td>
         </tr>

--- a/templates/elegant/show.tpl
+++ b/templates/elegant/show.tpl
@@ -224,7 +224,7 @@ Event.observe(document, 'dom:loaded', function() {
         {if $genres}
         <h3>{$lang.genres}:</h3>
         {foreach $genres as $genre}
-            <a href="search.php?q=&amp;genres[]={$genre.id}">{$lang.{$genre.name}}</a><br/>
+            <a href="search.php?q=&amp;genres[]={$genre.id}">{if $lang.{$genre.name}} {$lang.{$genre.name}} {else} {$genre.name} {/if}</a><br/>
         {/foreach}
         {/if}
     </td>

--- a/templates/elegant/show.tpl
+++ b/templates/elegant/show.tpl
@@ -224,7 +224,7 @@ Event.observe(document, 'dom:loaded', function() {
         {if $genres}
         <h3>{$lang.genres}:</h3>
         {foreach $genres as $genre}
-            <a href="search.php?q=&amp;genres[]={$genre.id}">{$genre.name}</a><br/>
+            <a href="search.php?q=&amp;genres[]={$genre.id}">{$lang.{$genre.name}}</a><br/>
         {/foreach}
         {/if}
     </td>

--- a/templates/modern/show.tpl
+++ b/templates/modern/show.tpl
@@ -179,7 +179,7 @@
       {if $genres}
           <b>{$lang.genres}:</b><br/>
             {foreach item=genre from=$genres}
-                  <a href="search.php?q=&genres[]={$genre.id}">{$lang.{$genre.name}}</a><br/>
+                  <a href="search.php?q=&genres[]={$genre.id}">{if $lang.{$genre.name}} {$lang.{$genre.name}} {else} {$genre.name} {/if} </a><br/>
             {/foreach}
       {/if}
     </td>

--- a/templates/modern/show.tpl
+++ b/templates/modern/show.tpl
@@ -179,7 +179,7 @@
       {if $genres}
           <b>{$lang.genres}:</b><br/>
             {foreach item=genre from=$genres}
-                  <a href="search.php?q=&genres[]={$genre.id}">{$genre.name}</a><br/>
+                  <a href="search.php?q=&genres[]={$genre.id}">{$lang.{$genre.name}}</a><br/>
             {/foreach}
       {/if}
     </td>

--- a/templates/modern/stats.tpl
+++ b/templates/modern/stats.tpl
@@ -32,7 +32,7 @@
           <td>
             <table cellspacing="0">
             {foreach item=row from=$stats.count_genre}
-              <tr><td><a href="search.php?q=&genres[]={$row.id}">{$lang.{$row.name}}</a>:</td><td>{$row.count}</td></tr>
+              <tr><td><a href="search.php?q=&genres[]={$row.id}"> {if $lang.{$row.name}} {$lang.{$row.name}} {else} {$row.name} {/if}</a>:</td><td>{$row.count}</td></tr>
             {/foreach}
             </table>
           </td>

--- a/templates/modern/stats.tpl
+++ b/templates/modern/stats.tpl
@@ -32,7 +32,7 @@
           <td>
             <table cellspacing="0">
             {foreach item=row from=$stats.count_genre}
-              <tr><td><a href="search.php?q=&genres[]={$row.id}">{$row.name}</a>:</td><td>{$row.count}</td></tr>
+              <tr><td><a href="search.php?q=&genres[]={$row.id}">{$lang.{$row.name}}</a>:</td><td>{$row.count}</td></tr>
             {/foreach}
             </table>
           </td>

--- a/templates/nexgen/edit.tpl
+++ b/templates/nexgen/edit.tpl
@@ -151,7 +151,7 @@
 				<div class="small-10 large-11 columns">
 					<dl class="sub-nav" input-checkbox>
 						{foreach $genres as $genre}
-						<dd {if $genre.checked}class="active"{/if}><a href="genres[]" value="{$genre.id}">{$genre.name}</a></dd>
+						<dd {if $genre.checked}class="active"{/if}><a href="genres[]" value="{$genre.id}">{$lang.{$genre.name}}</a></dd>
 						{/foreach}
 					</dl>
 				</div><!-- col -->

--- a/templates/nexgen/edit.tpl
+++ b/templates/nexgen/edit.tpl
@@ -151,7 +151,7 @@
 				<div class="small-10 large-11 columns">
 					<dl class="sub-nav" input-checkbox>
 						{foreach $genres as $genre}
-						<dd {if $genre.checked}class="active"{/if}><a href="genres[]" value="{$genre.id}">{$lang.{$genre.name}}</a></dd>
+						<dd {if $genre.checked}class="active"{/if}><a href="genres[]" value="{$genre.id}">{if $lang.{$genre.name}} {$lang.{$genre.name}} {else} {$genre.name} {/if}</a></dd>
 						{/foreach}
 					</dl>
 				</div><!-- col -->

--- a/templates/nexgen/search.tpl
+++ b/templates/nexgen/search.tpl
@@ -98,7 +98,7 @@
 				<div class="small-10 large-11 columns">
 					<dl class="sub-nav" input-checkbox>
 						{foreach $genres as $genre}
-						<dd {if $genre.checked}class="active"{/if}><a href="genres[]" value="{$genre.id}">{$lang.{$genre.name}}</a></dd>
+						<dd {if $genre.checked}class="active"{/if}><a href="genres[]" value="{$genre.id}">{if $lang.{$genre.name}} {$lang.{$genre.name}} {else} {$genre.name} {/if}</a></dd>
 						{/foreach}
 					</dl>
 				</div><!-- col -->

--- a/templates/nexgen/search.tpl
+++ b/templates/nexgen/search.tpl
@@ -98,7 +98,7 @@
 				<div class="small-10 large-11 columns">
 					<dl class="sub-nav" input-checkbox>
 						{foreach $genres as $genre}
-						<dd {if $genre.checked}class="active"{/if}><a href="genres[]" value="{$genre.id}">{$genre.name}</a></dd>
+						<dd {if $genre.checked}class="active"{/if}><a href="genres[]" value="{$genre.id}">{$lang.{$genre.name}}</a></dd>
 						{/foreach}
 					</dl>
 				</div><!-- col -->

--- a/templates/nexgen/show.tpl
+++ b/templates/nexgen/show.tpl
@@ -127,7 +127,7 @@ function boxeePlay(id) {
 					<div class="small-6 columns">
 						<p>{$lang.genres}:
 							{foreach $genres as $genre name=loop}
-							<a href="search.php?q=&amp;genres[]={$genre.id}">{$lang.{$genre.name}}</a>{if $smarty.foreach.loop.index < $smarty.foreach.loop.total-1}, {/if}
+							<a href="search.php?q=&amp;genres[]={$genre.id}">{if $lang.{$genre.name}} {$lang.{$genre.name}} {else} {$genre.name} {/if}</a>{if $smarty.foreach.loop.index < $smarty.foreach.loop.total-1}, {/if}
 							{/foreach}
 						</p>
 					</div><!-- col -->

--- a/templates/nexgen/show.tpl
+++ b/templates/nexgen/show.tpl
@@ -127,7 +127,7 @@ function boxeePlay(id) {
 					<div class="small-6 columns">
 						<p>{$lang.genres}:
 							{foreach $genres as $genre name=loop}
-							<a href="search.php?q=&amp;genres[]={$genre.id}">{$genre.name}</a>{if $smarty.foreach.loop.index < $smarty.foreach.loop.total-1}, {/if}
+							<a href="search.php?q=&amp;genres[]={$genre.id}">{$lang.{$genre.name}}</a>{if $smarty.foreach.loop.index < $smarty.foreach.loop.total-1}, {/if}
 							{/foreach}
 						</p>
 					</div><!-- col -->

--- a/templates/nexgen/stats.tpl
+++ b/templates/nexgen/stats.tpl
@@ -41,7 +41,7 @@
               	<div class="small-cols-1 large-cols-2">
           				<ul>
           					{foreach item=row from=$stats.count_genre}
-          					<li>{$row.count} <a href="search.php?q=&genres[]={$row.id}">{$row.name}</a></li>
+          					<li>{$row.count} <a href="search.php?q=&genres[]={$row.id}">{if $lang.{$row.name}} {$lang.{$row.name}} {else} {$row.name} {/if}</a></li>
           					{/foreach}
           				</ul>
                 </div>


### PR DESCRIPTION
There is a branch for genre translation but it seems to be to complicated and dead for 6 months.

**I believe genre translation should follow these basic rules which are followed in videodb:**
- Translations should be in lang files, just like any others.
- Translations should be applied in view layer (templates)

**What has been done:**
1. Added genre translation for English, German, Spanish, French and Polish languages. Other languages use English names.
2. Updated function out_genres() in core/output.php. It seems to be the only place in code (besides templates) that is required for full genre translation.
3. Updated all templates

**What can be done:**
1) Translation labels are direct genre names (Action, Horror). It can be changed to use prefix, for example: genre_Action, genre_Horror.
