### PR TITLE
Make videodb work with PHP 7.0

### DIFF
--- a/core/encoding.php
+++ b/core/encoding.php
@@ -115,11 +115,11 @@ function utf8_smart_decode($str)
 function html_entity_decode_all($string) 
 {
     // replace numeric entities
-    $string = preg_replace('~&#x([0-9a-f]+);~ei', 'chr(hexdec("\\1"))', $string);
-    $string = preg_replace('~&#([0-9]+);~e', 'chr(\\1)', $string);
+    $string = preg_replace_callback('~&#x([0-9a-f]+);~i', '_callback_chr_hexdec', $string);
+    $string = preg_replace_callback('~&#([0-9]+);~', '_callback_chr', $string);
 #   utf8 version commented out
-#    $string = preg_replace('~&#x([0-9a-f]+);~ei', 'code2utf(hexdec("\\1"))', $string);
-#    $string = preg_replace('~&#([0-9]+);~e', 'code2utf(\\1)', $string);
+#    $string = preg_replace_callback('~&#x([0-9a-f]+);~i', '_callback_code2utf_hexdec', $string);
+#    $string = preg_replace_callback('~&#([0-9]+);~', '_callback_code2utf', $string);
     
     // replace literal entities
     $trans_tbl = get_html_translation_table(HTML_ENTITIES);    
@@ -142,10 +142,10 @@ function html_entity_decode_all_utf8($string)
 {
     // replace numeric entities
 #   non-utf8 version commented out
-#    $string = preg_replace('~&#x([0-9a-f]+);~ei', 'chr(hexdec("\\1"))', $string);
-#    $string = preg_replace('~&#([0-9]+);~e', 'chr(\\1)', $string);
-    $string = preg_replace('~&#x([0-9a-f]+);~ei', 'code2utf(hexdec("\\1"))', $string);
-    $string = preg_replace('~&#([0-9]+);~e', 'code2utf(\\1)', $string);
+#    $string = preg_replace_callback('~&#x([0-9a-f]+);~i', '_callback_chr_hexdec', $string);
+#    $string = preg_replace_callback('~&#([0-9]+);~', '_callback_chr', $string);
+    $string = preg_replace_callback('~&#x([0-9a-f]+);~i', '_callback_code2utf_hexdec', $string);
+    $string = preg_replace_callback('~&#([0-9]+);~', '_callback_code2utf', $string);
     
     // replace literal entities
 #   non-utf8 version commented out
@@ -240,4 +240,39 @@ function html_to_text($str)
     return $str;
 }
 
+/**
+ * Ensure that there is only one match from a preg_replace_callback and return it
+ */
+function _get_only_match_from_callback($matches) {
+    assert(sizeof($matches) === 2);
+    return $matches[1];
+}
+
+/**
+ * apply chr on the only match of a preg_replace_callback
+ */
+function _callback_chr($matches) {
+    return chr(_get_only_match_from_callback($matches));
+}
+
+/**
+ * apply hexdec and chr on the only match of a preg_replace_callback
+ */
+function _callback_chr_hexdec($matches) {
+    return chr(hexdec(_get_only_match_from_callback($matches)));
+}
+
+/**
+ * apply code2utf on the only match of a preg_replace_callback
+ */
+function _callback_code2utf($matches) {
+    return code2utf(_get_only_match_from_callback($matches));
+}
+
+/**
+ * apply hexdec and code2utf on the only match of a preg_replace_callback
+ */
+function _callback_code2utf_hexdec($matches) {
+    return code2utf(hexdec(_get_only_match_from_callback($matches)));
+}
 ?>

--- a/core/security.php
+++ b/core/security.php
@@ -33,13 +33,23 @@ function removeEvilAttributes($tagSource)
 /**
  * @return string
  * @param string
+ * @desc Strip forbidden attributes from an array of matches for an expression like (<)(.*?)(>)
+ */
+function _callbackRemoveEvilAttributes($matches)
+{
+    return $matches[1] . removeEvilAttributes($matches[2]) . $matches[3];
+}
+
+/**
+ * @return string
+ * @param string
  * @desc Strip forbidden tags and delegate tag-source check to removeEvilAttributes()
  */
 function removeEvilTags($source)
 {
     global $allowedTags;
     $source = strip_tags($source, $allowedTags);
-    return preg_replace('/<(.*?)>/ie', "'<'.removeEvilAttributes('\\1').'>'", $source);
+    return preg_replace_callback('/(<)(.*?)(>)/i', "_callbackRemoveEvilAttributes", $source);
 }
 
 ?>

--- a/core/setup.core.php
+++ b/core/setup.core.php
@@ -63,7 +63,7 @@ function setup_mkOptions($isprofile = false)
     $setup[] = setup_addOption($isprofile, 'pageno', 'text');
     $setup[] = setup_addOption($isprofile, 'languageflags', 'special', out_languageflags($config['languages']));
     $setup[] = setup_addOption($isprofile, 'removearticles', 'boolean');
-    $setup[] = setup_addOption($isprofile, 'adultgenres', 'multi', setup_getGenres(), @split('::', $config['adultgenres']));
+    $setup[] = setup_addOption($isprofile, 'adultgenres', 'multi', setup_getGenres(), @explode('::', $config['adultgenres']));
     $setup[] = setup_addOption($isprofile, 'showtools', 'boolean');
 
     if (!$isprofile) $setup[] = setup_addSection('opt_custom');

--- a/lib/phpthumb/phpthumb.class.php
+++ b/lib/phpthumb/phpthumb.class.php
@@ -3999,7 +3999,6 @@ exit;
 							$this->DebugMessage('deleting "'.$tempfilename.'"', __FILE__, __LINE__);
 							unlink($tempfilename);
 							return $gdimg_source;
-							break;
 						} else {
 							$ErrorMessage = 'Failed to open tempfile in '.__FILE__.' on line '.__LINE__;
 							$this->DebugMessage($ErrorMessage, __FILE__, __LINE__);

--- a/lib/phpthumb/phpthumb.class.php
+++ b/lib/phpthumb/phpthumb.class.php
@@ -211,7 +211,7 @@ class phpthumb {
 	//////////////////////////////////////////////////////////////////////
 
 	// public: constructor
-	function phpThumb() {
+	function __construct() {
 		$this->DebugTimingMessage('phpThumb() constructor', __FILE__, __LINE__);
 		$this->DebugMessage('phpThumb() v'.$this->phpthumb_version, __FILE__, __LINE__);
 		$this->config_max_source_pixels = round(max(intval(ini_get('memory_limit')), intval(get_cfg_var('memory_limit'))) * 1048576 * 0.20); // 20% of memory_limit


### PR DESCRIPTION
These are all changes that I needed to run videodb on a PHP 7 environment. This at least allows to browse videos without errors and fixed adding/editing. These were all the problems which I noticed in the functionality that I use. Of course there might be more less obvious bugs due to the breaking changes in PHP 7, but I think this is the bare minimum of fixes that are needed.

This fixes #79. I tested the changes with PHP 5.6 and 7.0.