### PR TITLE
Get poster image url

### DIFF
--- a/engines/imdb.php
+++ b/engines/imdb.php
@@ -410,7 +410,17 @@ function imdbGetCoverURL($data) {
         }
     	$CLIENTERROR .= $resp['error']."\n";
     	return '';
-    } else {
+    } 
+    else if (preg_match('/<div.*?class="poster".*?<img.*?src="(.*?\.)_v.*?"/si', $data, $ary))
+    {
+        if ($ary[1]) 
+        {
+            return $ary[1]."jpg";
+        }
+        return '';
+    }
+    else 
+    {
         # no image
         return '';
     }


### PR DESCRIPTION
Added a new way of getting the cover image url. I have not removed the old way. Some movies are useing it. fx "The Rose".

I assume that the part "._V1_UX182_CR0,0,182,268_AL_" if a function that crops the image. By removing that we get a full size poster image.

Snipped of poster:
<div class="poster">
<a href="/title/tt1206543/mediaviewer/rm2864241664?ref_=tt_ov_i"> <img alt="Out of the Furnace Poster" title="Out of the Furnace Poster" src="http://ia.media-imdb.com/images/M/MV5BMTc2MTQ4MDU4NV5BMl5BanBnXkFtZTgwOTU1ODgzMDE@._V1_UX182_CR0,0,182,268_AL_.jpg" itemprop="image">
</a>    </div>