### PR TITLE
Fix for #89 missing TV episode

### DIFF
--- a/engines/imdb.php
+++ b/engines/imdb.php
@@ -195,32 +195,37 @@ function imdbData($imdbID)
     // add encoding
     $data['encoding'] = get_response_encoding($resp);
 
-
     // Check if it is a TV series episode
-    if (preg_match('/<div id="titleTVEpisodes"/i', $resp['data'])) {
-    #if (preg_match('/<div id="titleTVSeries"/i', $resp['data'])) {
+    if (preg_match('/<div id="title-episode-widget" class="table full-width">/i', $resp['data'])) {
         $data['istv'] = 1;
 
         # find id of Series
-        preg_match('/<a href="\/title\/tt(\d+)\/episodes.*?" title="Full Episode List.*"/i', $resp['data'], $ary);
+        preg_match('/<a href="\/title\/tt(\d+)\/episodes\?ref_=tt_ov_epl"/si', $resp['data'], $ary);
         $data['tvseries_id'] = trim($ary[1]);
     }
 
-   // Titles and Year
+    // Titles and Year
+    // See for different formats. https://contribute.imdb.com/updates/guide/title_formats
     if ($data['istv']) {
-        preg_match('/<meta name="title" content="&quot;(.*?)&quot;\s+(.*?)(.TV episode .*?)?( - IMDB)?"/si', $resp['data'], $ary);
-        $data['title'] = trim($ary[1]);
-        $data['subtitle'] = trim($ary[2]);
-#dlog($ary);
-        if (preg_match('/<h1 class="header".*?>.*?<span class="nobr">\(.*?(\d\d\d\d)\)</si', $resp['data'], $ary)) {
-            $data['year'] = $ary[1];
-        }
-    } else {
-        preg_match('/<meta name="title" content="(IMDb - )?(.*?) \(.*?(\d\d\d\d).*?\)( - IMDb)?" \/>/si', $resp['data'], $ary);
-#dlog($ary);
-        $data['year'] = trim($ary[3]);
+        preg_match('/<title>(.+?)\(TV Series (\d+).+?<\/title>/si', $resp['data'], $ary);
+        $data['year'] = $ary[2];
         # split title - subtitle
-        list($t, $s)	= explode(' - ', trim($ary[2]), 2);
+        list($t, $s) = explode(' - ', $ary[1], 2);
+        # no dash, lets try colon
+        if ($s == false) {
+            list($t, $s) = explode(': ', $ary[1], 2);	
+        }
+        $data['title'] = trim($t);
+        $data['subtitle'] = trim($s);
+    } else {
+        preg_match('/<title>(.+?)\((\d+)\).+?<\/title>/si', $resp['data'], $ary);
+        $data['year'] = trim($ary[2]);
+        # split title - subtitle
+        list($t, $s) = explode(' - ', $ary[1], 2);
+        # no dash, lets try colon
+        if ($s == false) {
+            list($t, $s) = explode(': ', $ary[1], 2);	
+        }
         $data['title'] = trim($t);
         $data['subtitle'] = trim($s);
     }


### PR DESCRIPTION
This fixes the missing TV-Episode.

It also fixes Title and Subtitle for Tv series and movies.
See https://contribute.imdb.com/updates/guide/title_formats for description of title formats.
Exsamples:
Star Wars: Episode III - Revenge of the Sith => Title is: "Star Wars: Episode III", and subtitle is: "Revenge of the Sith".
Jack Reacher: Never Go Back => Title is: "Jack Reacher" and subtitle is: "Never Go Back".
Mission: Impossible II => Title is: "Mission" and subtitle is "Implossible II".