### PR TITLE
PHP Warning:  count()

### DIFF
--- a/core/functions.php
+++ b/core/functions.php
@@ -452,9 +452,19 @@ function getActorThumbnail($name, $actorid = 0, $idSearchAllowed = true)
 	// identify actor by unique actor id, of by name
     if ($actorid && $idSearchAllowed) {
         $result = runSQL($SQL." WHERE actorid='".escapeSQL($actorid)."'");
-	}
-	if (!$actorid || (count($result) == 0)) {
-        $result = runSQL($SQL." WHERE name='".escapeSQL(html_entity_decode($name))."'");
+    }
+    // code for pre php 7.3
+    if (version_compare(PHP_VERSION_ID, 703007) < 0 && !function_exists("is_countable")) {
+        function is_countable($value) { 
+            return is_array($value) 
+                || $value instanceof Countable 
+                || $value instanceof ResourceBundle 
+                || $value instanceof SimpleXmlElement; 
+        }
+    }
+    // end for pre php 7.3
+    if (!$actorid || (is_countable($result) && count($result) == 0)) {
+    $result = runSQL($SQL." WHERE name='".escapeSQL(html_entity_decode($name))."'");
 	}
 
     $imgurl = get_actor_image_from_cache($result[0], $name, $actorid);

--- a/core/functions.php
+++ b/core/functions.php
@@ -454,7 +454,7 @@ function getActorThumbnail($name, $actorid = 0, $idSearchAllowed = true)
         $result = runSQL($SQL." WHERE actorid='".escapeSQL($actorid)."'");
     }
     // code for pre php 7.3
-    if (version_compare(PHP_VERSION_ID, 703007) < 0 && !function_exists("is_countable")) {
+    if (version_compare(PHP_VERSION, "7.3") < 0 && !function_exists("is_countable")) {
         function is_countable($value) { 
             return is_array($value) 
                 || $value instanceof Countable 

--- a/core/functions.php
+++ b/core/functions.php
@@ -453,7 +453,7 @@ function getActorThumbnail($name, $actorid = 0, $idSearchAllowed = true)
     if ($actorid && $idSearchAllowed) {
         $result = runSQL($SQL." WHERE actorid='".escapeSQL($actorid)."'");
     }
-    if (!$actorid || (is_array($result) && count($result) == 0)) {
+    if (!$actorid || ((is_array($result) && count($result) == 0)) ) {
         $result = runSQL($SQL." WHERE name='".escapeSQL(html_entity_decode($name))."'");
     }
 

--- a/core/functions.php
+++ b/core/functions.php
@@ -453,19 +453,9 @@ function getActorThumbnail($name, $actorid = 0, $idSearchAllowed = true)
     if ($actorid && $idSearchAllowed) {
         $result = runSQL($SQL." WHERE actorid='".escapeSQL($actorid)."'");
     }
-    // code for pre php 7.3
-    if (version_compare(PHP_VERSION, "7.3") < 0 && !function_exists("is_countable")) {
-        function is_countable($value) { 
-            return is_array($value) 
-                || $value instanceof Countable 
-                || $value instanceof ResourceBundle 
-                || $value instanceof SimpleXmlElement; 
-        }
+    if (!$actorid || (is_array($result) && count($result) == 0)) {
+        $result = runSQL($SQL." WHERE name='".escapeSQL(html_entity_decode($name))."'");
     }
-    // end for pre php 7.3
-    if (!$actorid || (is_countable($result) && count($result) == 0)) {
-    $result = runSQL($SQL." WHERE name='".escapeSQL(html_entity_decode($name))."'");
-	}
 
     $imgurl = get_actor_image_from_cache($result[0], $name, $actorid);
 


### PR DESCRIPTION
Clean up Warning messages
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in ......\videodb\core\functions.php on line 456.

As of php 7.3 the above is being signaled as a warning. add code to use is_countable function to check variable.
For pre php 7.3 users added code to emulate the is_countable function (can be removed once videodb is moved to minimum php version 7.3

Note: as of php 8 the warning will become an error level.
