### PR TITLE
Fix warnings pdf xml exports and coding errorr

### DIFF
--- a/core/export.core.php
+++ b/core/export.core.php
@@ -47,9 +47,9 @@ function exportData($WHERE)
     // do adultcheck
     if (is_array($result))
     {
-        $result = array_filter($result, create_function('$video', 'return adultcheck($video["id"]);'));
+         $result = array_filter($result, function($video) {return adultcheck($video["id"]);});
     }
-
+               
     // genres
     for($i=0; $i<count($result); $i++)
     {

--- a/core/pdf.php
+++ b/core/pdf.php
@@ -160,7 +160,7 @@ class PDF extends FPDF2File
 			else
 			{
 				//Tag
-				if($e{0}=='/')
+				if($e[0]=='/')
 				$this->CloseTag(strtoupper(substr($e,1)));
 				else
 				{

--- a/core/queryparser.php
+++ b/core/queryparser.php
@@ -98,7 +98,7 @@ function tokenizer($qstring)
 
     for ($i=0; $i < strlen($qstring); $i++)
     {
-        $char = $qstring{$i};
+        $char = $qstring[$i];
 
         // match current separator?
         if (preg_match("/$sep/", $char))

--- a/core/xml.php
+++ b/core/xml.php
@@ -27,9 +27,10 @@ function xmlexport($WHERE)
     $result = exportData($WHERE);
     
     // do adultcheck
+    // this may not be needed as same check is done in exportData in previous statement
     if (is_array($result))
     {
-        $result = array_filter($result, create_function('$video', 'return adultcheck($video["id"]);'));
+        $result = array_filter($result, function($video) {return adultcheck($video["id"]);});
     }
     
     $xml = '';
@@ -61,10 +62,10 @@ function xmlexport($WHERE)
         }
         
         // genres
-        if (count($row['genres']))
+        if (count($item['genres']))
         {
             $xml_genres = '';
-            foreach ($row['genres'] as $genre)
+            foreach ($item['genres'] as $genre)
             {
                 $xml_genres .= createTag('genre', $genre['name']);
             }

--- a/core/xml.php
+++ b/core/xml.php
@@ -45,7 +45,7 @@ function xmlexport($WHERE)
         {
             if (!empty($value))
             {
-                if (($key != 'owner_id') && ($key != 'actors'))
+                if (($key != 'owner_id') && ($key != 'actors') && ($key != 'genres'))
                 {
                     $tag       = strtolower($key);
                     $xml_item .= createTag($tag, trim(html_entity_decode_all($value)));

--- a/lib/fpdf2file/fpdf2file.php
+++ b/lib/fpdf2file/fpdf2file.php
@@ -9,6 +9,7 @@
  * @license Freeware 
  * @version $Id: fpdf2file.php,v 1.3 2010/04/04 08:51:06 andig2 Exp $
  * @version updated for fpdf v1.8 or above  copperhead 2022/12/18
+ * @override for FPDF_VERSION constant added copperhead 2023/01/05
  */
 
 //not requied by vidoeDB
@@ -20,7 +21,10 @@ protected $f;
 
 function Open($file='doc.pdf')
 {
-    if(FPDF_VERSION<'1.8')
+//  The FPDF_VERSION constant was replaced by a class constant in FPDF V1.85
+//  FPDF2FILE extension to lower memory consumption not yet updated  @ 2023/01/05
+//  if(FPDF_VERSION<'1.8')
+    if(self::VERSION<'1.8')
         $this->Error('Version 1.8 or above is required by this extension');
     $this->f=fopen($file,'wb');
     if(!$this->f)


### PR DESCRIPTION
Clean up of warnings in pdf/xml/FPDF2File and code errors
- replace create_function with anonymous function
- pdf.php replace { } with [ ]
- xml.php add code to exclude genres(array) in general tag creation (expects string) as handled latter in code.
- xml.php fix to code referencing incorrect variable $row instead of $item for genres
- reference new constant for version of FPDF in FPDF2file.php